### PR TITLE
Upstream upgrade to 23.10.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The [streams repository](https://codeberg.org/streams/streams/) lets you install
 Your websites will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **Funkwhale**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**Shipped version:** 23.10.17~ynh1
+**Shipped version:** 23.10.19~ynh1
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ Le [dépôt streams](https://codeberg.org/streams/streams/) vous permet d'instal
 Vos sites web seront compatibles avec **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **Funkwhale**, **Peertube**, **Plume**, **WriteFreely** et bien d'autres encore.
 
 
-**Version incluse :** 23.10.17~ynh1
+**Version incluse :** 23.10.19~ynh1
 
 ## Captures d’écran
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Streams"
 description.en = "Open source fediverse server"
 description.fr = "Serveur fediverse open source"
 
-version = "23.10.17~ynh1"
+version = "23.10.19~ynh1"
 
 maintainers = ["Papa Dragon"]
 
@@ -39,8 +39,8 @@ ram.runtime = "50M"
 [resources]
     [resources.sources]
         [resources.sources.main]
-        url = "https://codeberg.org/streams/streams/archive/5b1183d9606675c2768a968389b8dbc531b8701f.tar.gz"
-        sha256 = "04dcc0ef4194bfcbc643aa85c2ccc782df449ca6991d19a0be8fb34496a1483b"
+        url = "https://codeberg.org/streams/streams/archive/934c7b2b88e207ed413dc49d8e773f9896d54e20.tar.gz"
+        sha256 = "d52d1d111a1d46a1744652a4de573fb50bfea0f32bf703409d610324c1df4a76"
 
         [resources.sources.addons]
         url = "https://codeberg.org/streams/streams-addons/archive/39b1c5af9f2b1c639b6438ac85b0ea85273fc201.tar.gz"

--- a/tests.toml
+++ b/tests.toml
@@ -13,6 +13,6 @@ test_format = 1.0
     # Default args to use for install
     # -------------------------------
 
-    test_upgrade_from.7d95dde09194d8948e893a92a52a02a0a48cf33e.name = "Upgrade from 23.09.28~ynh2"
     test_upgrade_from.4a60421ef85ac193294fc057480a3469f4540e41.name = "Upgrade from 23.04.10~ynh1"
     test_upgrade_from.e7681e0867203dacb0d8f86f2a81587ba012a0b1.name = "Upgrade from 23.10.10~ynh1"
+    test_upgrade_from.5baaf0afb07836541456466f30a5bbfcf565db8e.name = "Upgrade from 23.10.17~ynh1"


### PR DESCRIPTION
## Problem

- Upstream upgrade to 23.10.19

## Solution

- Update manifest.toml & test.toml

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
