### PR TITLE
Wrong sha256 sum for addons

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -44,7 +44,7 @@ ram.runtime = "50M"
 
         [resources.sources.addons]
         url = "https://codeberg.org/streams/streams-addons/archive/39b1c5af9f2b1c639b6438ac85b0ea85273fc201.tar.gz"
-        sha256 = "6325e08b298839a0b370f405666d040af702c31437c4e90e0472e73f84864a8f"
+        sha256 = "5885665bf3dfbe843387184543be17b6b2061b807a57c1d6962548af80794f75"
 
     [resources.ports]
 

--- a/tests.toml
+++ b/tests.toml
@@ -13,6 +13,5 @@ test_format = 1.0
     # Default args to use for install
     # -------------------------------
 
-    test_upgrade_from.b95ec979addd17957566abc56e91dc0c8f81bbb3.name = "Upgrade from 23.10.24~ynh1"
-    test_upgrade_from.398eebfc799b8d84cb4a32eecdc8558443226ace.name = "Upgrade from 23.10.30~ynh1"
-    test_upgrade_from.2963cefcde42642e57f4255627342e42ef74ce01.name = "Upgrade from 23.11.05~ynh1"
+#   test_upgrade_from.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.name = "Upgrade from xx.xx.xx~ynhx"
+


### PR DESCRIPTION
## Problem

- Hash mismatch for addons

## Solution

- Correction of sha256 for addons in manifest.toml

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
