### PR TITLE
Add php8.2-gmp to manifest.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The [streams repository](https://codeberg.org/streams/streams/) lets you install
 Your websites will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **Funkwhale**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**Shipped version:** 23.11.14~ynh1
+**Shipped version:** 23.12.17~ynh1
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ Le [dépôt streams](https://codeberg.org/streams/streams/) vous permet d'instal
 Vos sites web seront compatibles avec **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **Funkwhale**, **Peertube**, **Plume**, **WriteFreely** et bien d'autres encore.
 
 
-**Version incluse :** 23.11.14~ynh1
+**Version incluse :** 23.12.17~ynh1
 
 ## Captures d’écran
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Streams"
 description.en = "Open source fediverse server"
 description.fr = "Serveur fediverse open source"
 
-version = "23.11.14~ynh1"
+version = "23.12.17~ynh1"
 
 maintainers = ["Papa Dragon"]
 
@@ -50,7 +50,7 @@ ram.runtime = "50M"
     main.url = "/"
 
     [resources.apt]
-    packages = "php8.2-mbstring, php8.2-cli, php8.2-imagick, php8.2-xml, php8.2-zip, php8.2-curl, php8.2-ldap, php8.2-gd, mariadb-server, php8.2-mysql"
+    packages = "php8.2-mbstring, php8.2-cli, php8.2-imagick, php8.2-xml, php8.2-zip, php8.2-curl, php8.2-ldap, php8.2-gd, mariadb-server, php8.2-mysql php8.2-gmp"
 
     [resources.database]
     type = "mysql"

--- a/tests.toml
+++ b/tests.toml
@@ -13,6 +13,5 @@ test_format = 1.0
     # Default args to use for install
     # -------------------------------
 
-    test_upgrade_from.5112b799be49c5768416ca8c23efd0afbba9cfb5.name = "Upgrade from 23.11.05~ynh3"
-    test_upgrade_from.d9393d31c20fca899e8e13650cb79f2c0846e81a.name = "Upgrade from 23.11.11~ynh1"
+    test_upgrade_from.00ccbbeb7e3da0209698ff12cdeb274a27f048af.name = "Upgrade from 23.11.14~ynh1"
 


### PR DESCRIPTION
## Problem

- php8.2 will soon be required for installation in upstream, already is for those using dev branch

## Solution

- Add php8.2-gmp to manifest.toml so we're ready for the next release update

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
