### PR TITLE
Update .htconfig.php & additional preinstall option

### DIFF
--- a/conf/htconfig.sample.php
+++ b/conf/htconfig.sample.php
@@ -1,23 +1,14 @@
 <?php
 
-// If automatic system installation fails: 
+// Set the following for your database installation
+// Copy or rename this file to .htconfig.php
 
-// Copy or rename this file to .htconfig.php in the top level 
-// Hubzilla directory
-
-// Why .htconfig.php? Because it contains sensitive information which could
-// give somebody complete control of your database. Apache's default 
-// configuration denies access to and refuses to serve any file beginning 
-// with .ht
-
-// Then set the following for your MySQL installation
-
-$db_host = 'localhost'; // Use 'localhost' or ':/path/to/socket.file' if you aren't using a remote server
-$db_port = 0;                    // leave 0 for default or set your port
+$db_host = 'localhost';
+$db_port = 0;
 $db_user = '__DB_USER__';
 $db_pass = '__DB_PWD__';
 $db_data = '__DB_NAME__';
-$db_type = 0; // use 1 for postgres, 0 for mysql
+$db_type = 0; // an integer. 0 or unset for mysql, 1 for postgres
 
 /*
  * Notice: Many of the following settings will be available in the admin panel 
@@ -35,14 +26,13 @@ $db_type = 0; // use 1 for postgres, 0 for mysql
 // Choose a legal default timezone. If you are unsure, use "America/Los_Angeles".
 // It can be changed later and only applies to timestamps for anonymous viewers.
 
-App::$config['system']['timezone'] = 'America/Los_Angeles';
+App::$config['system']['timezone'] = '__TIMEZONE__';
 
-// What is your site name? DO NOT ADD A TRAILING SLASH!
+// What is your site url? DO NOT ADD A TRAILING SLASH!
 
 App::$config['system']['baseurl'] = 'https://__DOMAIN__';
 App::$config['system']['sitename'] = "YunoHost Streams";
 App::$config['system']['location_hash'] = '__RANDOM_STRING__';
-
 
 // These lines set additional security headers to be sent with all responses
 // You may wish to set transport_security_header to 0 if your server already sends
@@ -53,42 +43,126 @@ App::$config['system']['transport_security_header'] = 1;
 App::$config['system']['content_security_policy'] = 1;
 App::$config['system']['ssl_cookie_protection'] = 1;
 
-
 // Your choices are REGISTER_OPEN, REGISTER_APPROVE, or REGISTER_CLOSED.
 // Be certain to create your own personal account before setting 
 // REGISTER_CLOSED. 'register_text' (if set) will be displayed prominently on 
 // the registration page. REGISTER_APPROVE requires you set 'admin_email'
 // to the email address of an already registered person who can authorise
-// and/or approve/deny the request. 
-
-// In order to perform system administration via the admin panel, admin_email
-// must precisely match the email address of the person logged in.
+// and/or approve/deny the request.
 
 App::$config['system']['register_policy'] = REGISTER_OPEN;
 App::$config['system']['register_text'] = '';
 App::$config['system']['admin_email'] = '__EMAIL__';
 
+// Recommend you leave this set to 1. Set to 0 to let people register without 
+// proving they own the email address they register with.
+
+App::$config['system']['verify_email'] = 0;
+
+// Site access restrictions. By default we will create private sites.
+// Your choices are ACCESS_PRIVATE, ACCESS_PAID, ACCESS_TIERED, and ACCESS_FREE.
+// If you leave REGISTER_OPEN above, anybody may register on your
+// site, however your site will not be listed anywhere as an open
+// registration  hub. We will use the system access policy (below) 
+// to determine whether or not to list your site in the directory 
+// as an open hub where anybody may create accounts. Your choice of 
+// paid, tiered, or free determines how these listings will be presented.  
+
+App::$config['system']['access_policy'] = ACCESS_PRIVATE;
+
+// This software has a focus on online safety and user privacy. The default
+// channel configuration is a restricted role where all posts are private to
+// your connections and one needs to change the audience manually in order to
+// create a public post ('social_restricted'). You might want to instead
+// change this to post publicly by default, and require a manual change to
+// restrict the audience to only your connections. To do that, change this
+// to 'social'.  
+    
+App::$config['system']['default_permissions_role'] = 'social_restricted';
+
+// This setting affects the quality of the site directory and friend suggestions.
+// It controls how many "friends of friends" to import into your site from connections
+// that are made on this site. Every digit increase can have a dramatic effect on disk
+// and database use depending on the size of your site and the number of connections that
+// have been made. If set to 100 or more and you have more than a dozen local accounts,
+// each with a modest number of connections, your directory could ultimately discover most
+// of the known fediverse, or tens of millions of entries.
+// The default setting of 10 will provide you with a very well connected fediverse instance
+// with an interesting and well-rounded directory, and provide good quality friend suggestions.
+// You might wish to reduce this or change it to 0 if resource use is a concern.
+// The quality of your directory and friend suggestions will decrease accordingly. If you
+// raise it, it is recommend that you raise it incrementally and not make large or sudden
+// jumps, as this could quickly mushroom into millions or tens of millions of new
+// directory records.
+
+App::$config['system']['max_imported_follow'] = __MAX_IMPORTED_FOLLOW__; 
+
+// If you operate a public site, you might wish that people are directed
+// to a "sellpage" where you can describe for features or policies or service plans in depth.
+// This must be an absolute URL beginning with http:// or https:// .
+
+App::$config['system']['sellpage'] = '';
+
+// Maximum size of an imported message, 0 is unlimited
+
+App::$config['system']['max_import_size'] = 200000;
+
 // Location of PHP command line processor
 
 App::$config['system']['php_path'] = '/usr/bin/php__PHPVERSION__';
 
-
 // Configure how we communicate with directory servers.
-// DIRECTORY_MODE_NORMAL     = directory client, we will find a directory (all of your member's queries will be directed elsewhere)
-// DIRECTORY_MODE_SECONDARY  = caching directory or mirror (keeps in sync with realm primary [adds significant cron execution time])
-// DIRECTORY_MODE_PRIMARY    = main directory server (you do not want this unless you are operating your own realm. one per realm.)
-// DIRECTORY_MODE_STANDALONE = "off the grid" or private directory services (only local site members in directory)
-
+// Deprecated. Please do not change.
 App::$config['system']['directory_mode']  = DIRECTORY_MODE_NORMAL;
+
+// default system theme
+App::$config['system']['theme'] = 'fresh';
+
+// Allow local test environments with unverified SSL certs using Lando
+App::$config['system']['ssl_exceptions'] = 'lndo.site';
+
+// Mail configuration
+// By default, uses local sendmail service
+// Only change these settings if you require SMTP transport
+
+// App::$config['phpmailer']['mailer'] = 'smtp';
+// App::$config['phpmailer']['host'] = 'example.com';
+
+// Leave this line commented if using SSL or STARTTLS and set the port in the next sections
+// App::$config['phpmailer']['port'] = 25;  // (or 587 or 465 if using ssl)
+
+// If using smtp authentication:
+// App::$config['phpmailer']['smtpauth'] = 1;
+// App::$config['phpmailer']['uername'] = 'your_username';
+// App::$config['phpmailer']['password'] = 'your_secret_password';
+
+// If using starttls:
+// App::$config['phpmailer']['smtpsecure'] = 'tls';
+// App::$config['phpmailer']['port'] = 587;
+
+// If using ssl:
+// App::$config['phpmailer']['smtpsecure'] = 'ssl';
+// App::$config['phpmailer']['port'] = 465;
+
+// If the server has a self-signed cert:
+// App::$config['phpmailer']['noverify'] = 1;
+
+// For debugging
+// App::$config['phpmailer']['smtpdebug'] = 2; // valid values are 0-4
+
+// These settings should work for 99% of use cases
+// If you encounter any issues, please see  https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting
+// If you need to extend these configuration options, please submit a pull request with your changes.
 
 
 // PHP error logging setup
 // Before doing this ensure that the webserver has permission
-// to create and write to php.out in the top level Red directory,
+// to create and write to php.log in the top level web directory,
 // or change the name (below) to a file/path where this is allowed.
 
-// Uncomment the following 4 lines to turn on PHP error logging.
-error_reporting(E_ERROR | E_PARSE ); 
-ini_set('error_log','php.log');
-ini_set('log_errors','1');
 ini_set('display_errors', '0');
+
+// Uncomment the following lines to turn on PHP error logging.
+error_reporting(E_ERROR | E_PARSE ); 
+ini_set('error_log','php.log'); 
+ini_set('log_errors','1');

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Streams"
 description.en = "Open source fediverse server"
 description.fr = "Serveur fediverse open source"
 
-version = "23.12.17~ynh1"
+version = "24.02.18~ynh1"
 
 maintainers = ["Papa Dragon"]
 
@@ -35,6 +35,14 @@ ram.runtime = "50M"
 
     [install.admin]
     type = "user"
+
+    [install.activate_directory]
+    ask.en = "Do you want to activate the directory?"
+    ask.fr = "Voulez-vous activer l'annuaire ?"
+    help.en = "The site directory and friends suggestions are populated importing 'friends of friends' from connections that are made on your site. You might wish to disable this if your server has limited resources. This can be changed later in your website's Admin interface."
+    help.fr = "L'annuaire du site et les suggestions d'amis sont alimentés par l'importation des 'amis d'amis' à partir des connexions établies sur votre site. Vous pouvez désactiver cette fonction si votre serveur dispose de ressources limitées. Ce réglage peut être modifié ultérieurement dans l'interface d'administration de votre site."
+    type = "boolean"
+    default = true
 
 [resources]
 

--- a/scripts/install
+++ b/scripts/install
@@ -105,6 +105,15 @@ ynh_mysql_connect_as --user="$db_name" --password="$db_pwd" --database="$db_name
 #=================================================
 ynh_script_progression --message="Adding a configuration file..." --weight=1
 
+timezone=$(</etc/timezone)
+
+if [ $activate_directory -eq 1 ]
+then
+    max_imported_follow=10
+else
+    max_imported_follow=0
+fi
+
 ynh_add_config --template="../conf/htconfig.sample.php" --destination="$install_dir/.htconfig.php"
 
 ynh_store_file_checksum --file=$install_dir/.htconfig.php

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -119,6 +119,9 @@ popd
 #=================================================
 ynh_script_progression --message="Updating a configuration file..." --weight=1
 
+timezone=$(</etc/timezone)
+max_imported_follow=10
+
 ynh_add_config --template="../conf/htconfig.sample.php" --destination="$install_dir/.htconfig.php"
 
 chmod 600 "$install_dir/.htconfig.php"


### PR DESCRIPTION
## Problem

- .htconfig.php.sample needed an update
- Disabling the directory before installing was requested by some users

## Solution

- htconfig.php.sample updated
- An option now allows you to install a website with the directory disabled (actually not populated with your friend's friends)

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
