### PR TITLE
Tiny fix in upgrade script

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -35,6 +35,10 @@ ynh_setup_source --dest_dir="$install_dir/addon" --source_id="addons"
 
 # We restore symlinks to stuff in $data_dir
 ynh_exec_as_app ln -s $data_dir/store $install_dir/
+if [ -d "$install_dir/cache" ]
+then
+    ynh_safe_rm $install_dir/cache
+fi
 ynh_exec_as_app ln -s $data_dir/cache $install_dir/
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -18,29 +18,24 @@ ynh_script_progression "Ensuring downward compatibility..."
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
+ynh_script_progression "Upgrading source files..."
 
-# FIXME: this is still supported but the recommendation is now to *always* re-setup the app sources wether or not the upstream sources changed
-if ynh_app_upstream_version_changed
+# Move data to the data_dir if it's still in install_dir
+if [ ! -d "$data_dir/store" ]
 then
-    	ynh_script_progression "Upgrading source files..."
-
-    # Move data to the data_dir if it's still in install_dir
-    if [ ! -d "$data_dir/store" ]
-    then
-        ynh_exec_as_app mv $install_dir/store $data_dir/
-        ynh_exec_as_app mv $install_dir/cache $data_dir/
-    fi
-
-    # Then we remove the previous install
-    ynh_safe_rm $install_dir
-
-    ynh_setup_source --dest_dir="$install_dir"
-    ynh_setup_source --dest_dir="$install_dir/addon" --source_id="addons"
-
-    # We restore what we previously saved
-    ynh_exec_as_app ln -s $data_dir/store $install_dir/
-    ynh_exec_as_app ln -s $data_dir/cache $install_dir/
+    ynh_exec_as_app mv $install_dir/store $data_dir/
+    ynh_exec_as_app mv $install_dir/cache $data_dir/
 fi
+
+# Then we remove the previous install
+ynh_safe_rm $install_dir
+
+ynh_setup_source --dest_dir="$install_dir"
+ynh_setup_source --dest_dir="$install_dir/addon" --source_id="addons"
+
+# We restore symlinks to stuff in $data_dir
+ynh_exec_as_app ln -s $data_dir/store $install_dir/
+ynh_exec_as_app ln -s $data_dir/cache $install_dir/
 
 #=================================================
 # PHP-FPM CONFIGURATION


### PR DESCRIPTION
## Problem

- If there's an access to the website while the upgrade is being performed this might cause the creation of a `cache` folder in `$install_dir,` while we need to run `ln -s $data_dir/cache $install_dir/` at some point.
If someone visits the website during the upgrade, the upgrade can fail.

## Solution

- Make sure there's no `cache` folder in $`install_dir` immediatly before running the `ln -s` command.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
