### PR TITLE
update addons source + install fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It shall NOT be edited by hand.
 
 Open source fediverse server
 
-[![Version: 25.7.22~ynh1](https://img.shields.io/badge/Version-25.7.22~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/streams/)
+[![Version: 25.7.22~ynh2](https://img.shields.io/badge/Version-25.7.22~ynh2-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/streams/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/streams"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Streams"
 description.en = "Open source fediverse server"
 description.fr = "Serveur fediverse open source"
 
-version = "25.7.22~ynh1"
+version = "25.7.22~ynh2"
 
 maintainers = ["Papa Dragon"]
 
@@ -55,8 +55,8 @@ ram.runtime = "50M"
         autoupdate.version_regex = "^v(.*)$"
 
         [resources.sources.addons]
-        url = "https://codeberg.org/streams/streams-addons/archive/746dfb6ab01c972e96554ce51c1e418353124c35.tar.gz"
-        sha256 = "46645302f345d49b59f80cfe9fab1bdddf5efb928a2165f4f0f43b304245f03e"
+        url = "https://codeberg.org/streams/streams-addons/archive/v25.7.22.tar.gz"
+        sha256 = "e20fc18f94b9795090e115d56380e03e3c14be35210ba480bc109864143863a3"
         autoupdate.strategy = "latest_forgejo_commit"
         autoupdate.upstream = "https://codeberg.org/streams/streams-addons"
 

--- a/scripts/install
+++ b/scripts/install
@@ -29,10 +29,13 @@ ynh_script_progression "Setting up source files..."
 ynh_setup_source --dest_dir="$install_dir"
 ynh_setup_source --dest_dir="$install_dir/addon" --source_id="addons"
 
-ynh_exec_as_app mkdir -p "$install_dir/store"
-ynh_exec_as_app mkdir -p  "$install_dir/cache/smarty3"
+ynh_exec_as_app mkdir -p "$data_dir/store"
+ynh_exec_as_app mkdir -p "$data_dir/cache/smarty3"
 
-ynh_exec_as_app chmod -R 775 $install_dir/store $install_dir/cache
+ynh_exec_as_app chmod -R 775 $data_dir/store $data_dir/cache
+
+ynh_exec_as_app ln -s $data_dir/store $install_dir/
+ynh_exec_as_app ln -s $data_dir/cache $install_dir/
 
 #=================================================
 # PHP-FPM CONFIGURATION


### PR DESCRIPTION
## Problem

- Addons source was not update after previous auto-update
- cache & store folder now need to be installed in data_dir

## Solution

- Addons source updated + auto-update strategy modified (now watching tags) 
- Install script modified

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
