### PR TITLE
Resources12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It shall NOT be edited by hand.
 
 Open source fediverse server
 
-[![Version: 25.8.22~ynh1](https://img.shields.io/badge/Version-25.8.22~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/streams/)
+[![Version: 25.8.22~ynh2](https://img.shields.io/badge/Version-25.8.22~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/streams/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/streams"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Streams"
 description.en = "Open source fediverse server"
 description.fr = "Serveur fediverse open source"
 
-version = "25.8.22~ynh1"
+version = "25.8.22~ynh2"
 
 maintainers = ["Papa Dragon"]
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,5 +6,4 @@
 # PHP APP SPECIFIC
 #=================================================
 
-#REMOVEME? composer_version="2.7.8"
 YNH_PHP_VERSION="8.3"

--- a/scripts/install
+++ b/scripts/install
@@ -37,6 +37,8 @@ ynh_exec_as_app chmod -R 775 $data_dir/store $data_dir/cache
 ynh_exec_as_app ln -s $data_dir/store $install_dir/
 ynh_exec_as_app ln -s $data_dir/cache $install_dir/
 
+chown -R "$app:www-data" "$install_dir"
+
 #=================================================
 # PHP-FPM CONFIGURATION
 #=================================================
@@ -53,7 +55,6 @@ ynh_config_add_nginx
 #=================================================
 ynh_script_progression "Pulling in external libraries with Composer..."
 
-#REMOVEME? ynh_composer_install
 ynh_composer_exec install --no-dev
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -57,7 +57,12 @@ ynh_config_add_nginx
 #=================================================
 ynh_script_progression "Pulling in external libraries with Composer..."
 
-#REMOVEME? ynh_composer_install
+# Workaround for upgrade from previous resources version (prior to 12.1)
+if [ $(stat -c %u $install_dir/composer.phar) == 0 ]
+then
+    chown streams:www-data $install_dir/composer.phar
+fi
+
 ynh_composer_exec install --no-dev
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -38,6 +38,8 @@ then
 fi
 ynh_exec_as_app ln -s $data_dir/cache $install_dir/
 
+chown -R "$app:www-data" "$install_dir"
+
 #=================================================
 # PHP-FPM CONFIGURATION
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -58,7 +58,7 @@ ynh_config_add_nginx
 ynh_script_progression "Pulling in external libraries with Composer..."
 
 # Workaround for upgrade from previous resources version (prior to 12.1)
-if [ $(stat -c %u $install_dir/composer.phar) == 0 ]
+if [[ $(stat -c %u $install_dir/composer.phar) == "0" ]]
 then
     chown streams:www-data $install_dir/composer.phar
 fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -27,11 +27,8 @@ then
     ynh_exec_as_app mv $install_dir/cache $data_dir/
 fi
 
-# Then we remove the previous install
-ynh_safe_rm $install_dir
-
-ynh_setup_source --dest_dir="$install_dir"
-ynh_setup_source --dest_dir="$install_dir/addon" --source_id="addons"
+ynh_setup_source --dest_dir="$install_dir" --full_replace --keep="composer.phar"
+ynh_setup_source --dest_dir="$install_dir/addon" --source_id="addons" --full_replace
 
 # We restore symlinks to stuff in $data_dir
 ynh_exec_as_app ln -s $data_dir/store $install_dir/
@@ -56,12 +53,6 @@ ynh_config_add_nginx
 # COMPOSER
 #=================================================
 ynh_script_progression "Pulling in external libraries with Composer..."
-
-# Workaround for upgrade from previous resources version (prior to 12.1)
-if [[ $(stat -c %u $install_dir/composer.phar) == "0" ]]
-then
-    chown streams:www-data $install_dir/composer.phar
-fi
 
 ynh_composer_exec install --no-dev
 


### PR DESCRIPTION
## Problem

- Upgrade doesn't work when using 12.1 resources, error due to permissions on composer.phar file

## Solution

- Run a chown on composer.phar prior to running ynh_composer_exec install

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
